### PR TITLE
Add naive command line installation

### DIFF
--- a/command.c
+++ b/command.c
@@ -56,6 +56,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/stat.h>
 
 #include <stubinfo.h>
@@ -72,6 +73,7 @@
 #ifdef __DJGPP__
 #include <crt0.h>
 #include <dpmi.h>
+#include <go32.h>
 extern char **environ;
 
 #define UNUSED __attribute__((unused))
@@ -132,6 +134,80 @@ static void perform_external_cmd(int call, char *ext_cmd);
 static void perform_set(const char *arg);
 static void list_cmds(void);
 //static void perform_unimplemented_cmd(void);
+
+static int installable_command_check(const char *name, const char *cmdline) {
+  /* from RBIL
+
+  AX = AE00h
+  DX = magic value FFFFh
+  CH = FFh
+  CL = length of command line tail (4DOS v4.0)
+  DS:BX -> command line buffer (see #02977)
+  DS:SI -> command name buffer (see #02978)
+  DI = 0000h (4DOS v4.0)
+
+  Return:
+  AL = FFh if this command is a TSR extension to COMMAND.COM
+  AL = 00h if the command should be executed as usual
+
+
+  Format of COMMAND.COM command line buffer:
+
+  Offset  Size    Description     (Table 02977)
+  00h    BYTE    max length of command line, as in INT 21/AH=0Ah
+  01h    BYTE    count of bytes to follow, excluding terminating 0Dh
+  N BYTEs   command line text, terminated by 0Dh
+
+
+  Format of command name buffer:
+
+  Offset  Size    Description     (Table 02978)
+  00h    BYTE    length of command name
+  01h  N BYTEs   uppercased command name (blank-padded to 11 chars by 4DOS v4)
+
+  */
+
+  const char *p;
+  char *q;
+
+  struct {
+    uint8_t nlen;
+    char nbuf[11];
+
+    uint8_t cmax;
+    uint8_t clen;
+    char cbuf[256];
+  } __attribute__((packed)) s;
+
+  if (strlen(name) > sizeof(s.nbuf))
+    return 0;
+  for (p = name, q = &s.nbuf[0]; *p && *p != '.' && !isspace(*p); p++, q++) {
+    *q = toupper(*p);
+  }
+  s.nlen = q - &s.nbuf[0];
+
+  if (strlen(cmdline) >= sizeof(s.cbuf))
+    return 0;
+  s.cmax = sizeof(s.cbuf) - 1;
+  s.clen = snprintf(s.cbuf, sizeof(s.cbuf), "%s", cmdline) - 1;
+
+  __dpmi_regs regs;
+
+  regs.x.ax = 0xae00;
+  regs.x.cx = 0xff00;
+  regs.x.dx = 0xffff;
+
+  regs.x.ds = __tb >> 4;      // transfer buffer address in DS:SI
+  regs.x.si = __tb & 0x0f;
+
+  regs.x.bx = regs.x.si + 12; // offset to cmax within transfer buffer
+
+  dosmemput(&s, sizeof(s), __tb);
+
+  __dpmi_int(0x2f, &regs);
+
+  return (regs.x.ax & 0xff) == 0xff;
+}
 
 /***
 *
@@ -3038,6 +3114,10 @@ int main(int argc, char *argv[], char *envp[])
   int a;
   char *cmd_path;
   // initialize the cmd data ...
+
+  // Indicate to Dosemu that the DOS has booted. This may be removed after
+  // comcom32 supports installable commands properly.
+  installable_command_check("comcom32", "\r");
 
   // reset fpu
   _clear87();


### PR DESCRIPTION
This should be enough to fix #4 as once MFS is enabled the normal MFS mangling to SFN should be available. I don't think we need to enable the LFN processing in comcom32 (via crt0 flags) as it changes the output of 'DIR' both in case and filename length, although it's cool to see.